### PR TITLE
Update helm-install.sh to include CHART_LOCATION

### DIFF
--- a/charts/cf-idw/helm-install.sh
+++ b/charts/cf-idw/helm-install.sh
@@ -5,18 +5,19 @@ HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-cf-idw}
 NAMESPACE=${NAMESPACE:-${HELM_RELEASE_NAME}-services}
 WITNESS_COUNT=${WITNESS_COUNT:-6}
 PUBLIC_DOMAINS=${PUBLIC_DOMAINS:-3x4mpl3.com,example.com}
+CHART_LOCATION=${CHART_LOCATION:-.}
 
 helm repo add cardano-foundation https://cardano-foundation.github.io/cf-helm-charts
 
 helm install \
   ${HELM_RELEASE_NAME} \
+  ${CHART_LOCATION} \
   --create-namespace \
   --namespace ${NAMESPACE} \
   --set ingressTLDs="{$PUBLIC_DOMAINS}" \
-  --set witness.witnessCount=${WITNESS_COUNT} \
-  .
+  --set witness.witnessCount=${WITNESS_COUNT}
 
-echo "[+] Install script is now updating your deployment to use the self-hosted witnesses...
+echo "[+] Install script is now updating your deployment to use the self-hosted witnesses..."
 
 helm get notes -n ${NAMESPACE} ${HELM_RELEASE_NAME} | grep -v ^NOTES > /tmp/$$.helm.notes.sh
 


### PR DESCRIPTION
When users follow the installation instructions and download the script using: curl -so /tmp/helm-install.sh https://raw.githubusercontent.com/cardano-foundation/cf-helm-charts/refs/heads/main/charts/cf-idw/helm-install.sh The script fails to execute because it references a local chart directory (.) that doesn't exist in the user's current working directory. This change introduces the CHART_LOCATION variable to make the chart reference configurable. The default remains . to preserve the original behaviour for repository-based workflows, but users can now override it to reference the remote Helm repository.