### PR TITLE
fix(yaci-address-balance-monitor): correct serviceMonitor values path for prometheusReleaseLabel

### DIFF
--- a/charts/yaci-address-balance-monitor/templates/service-monitor.yaml
+++ b/charts/yaci-address-balance-monitor/templates/service-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: yaci-address-balance-monitor
   labels:
     # This should match your prometheus release label
-    release: {{ .Values.prometheusReleaseLabel | default "cf-eks-monitoring" }}
+    release: {{ .Values.serviceMonitor.prometheusReleaseLabel | default "cf-eks-monitoring" }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The template was reading `.Values.prometheusReleaseLabel` which doesn't exist, causing it to always fall back to the hardcoded default `cf-eks-monitoring` and ignoring any user-provided value.

The correct path, matching the structure in `values.yaml`, is `.Values.serviceMonitor.prometheusReleaseLabel`.